### PR TITLE
fix: update root url for api docs

### DIFF
--- a/server/src/script/module/modifyGeneratedAPIDocs.ts
+++ b/server/src/script/module/modifyGeneratedAPIDocs.ts
@@ -78,7 +78,7 @@ export function modifyGeneratedAPIDocs(savePathAndFilename: string): OpenAPIV3.D
 
 const docsServers: OpenAPIV3.ServerObject[] = [
 	{
-		url: "https://ts.kipras.org",
+		url: "https://tvarkarastis.com",
 		// "description": "Main server"
 	},
 	// {


### PR DESCRIPTION
the other stuff was old and deprecated - I'm surprized that I've missed it
and that it still worked lol