### PR TITLE
fix(ci): update to latest github actions syntax

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -99,7 +99,7 @@ jobs:
 
             # get the latest tag
             # see https://github.com/actions/starter-workflows/issues/68#issuecomment-552074596
-            - run: echo "::set-env name=LATEST_TAG::$(git describe --tags --abbrev=0)"
+            - run: echo "LATEST_TAG=$(git describe --tags --abbrev=0) >> $GITHUB_ENV"
 
             # print for debugging
             - run: echo "$LATEST_TAG"


### PR DESCRIPTION
as per
    
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
- https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-an-environment-variable
