### PR TITLE
fix/avoid-scraper-ddosing-upstream

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ yarn-error.log*
 lerna-debug.log*
 
 .yarn-integrity
+
+rectifier

--- a/DEPLOYING.md
+++ b/DEPLOYING.md
@@ -1,0 +1,42 @@
+# Deploying
+
+We'll deploy the [kipras/turbo-schedule](https://hub.docker.com/r/kipras/turbo-schedule) docker image on a single VPS.
+
+## I. Setting up a VPS
+
+Refer to the latest documentation/tutorial on how to setup a nodejs/docker application on some VPS, i.e. digital ocean.
+
+Here's a backup of guides that were used at the time I setup my server that I still use to this day to host turbo-schedule:
+
+https://github.com/kiprasmel/ubuntu-server-setup
+
+You'll need almost everything from there if you're starting fresh, except `#6` - instead of a nodejs app, we'll just use our docker image.
+
+## II. One-time prerequisites
+
+### II 1. nginx config
+
+<++>
+
+### II 2. (persistant) docker volumes
+
+<++>
+
+### II 3. SSL
+
+<++>
+
+## Running & updating the container image
+
+```sh
+docker stop turbo-schedule # error ok
+docker rename turbo-schedule turbo-schedule.old # error ok if previous also errored
+docker run \
+	-p 7000:5000 \
+	--detach \
+	--name turbo-schedule \
+	--mount source=turbo-schedule--generated,target=/usr/src/app/server/generated \
+	--mount source=turbo-schedule--database,target=/usr/src/app/database/data \
+	kipras/turbo-schedule && \
+docker rm turbo-schedule.old # error ok if prev-previous also errored
+```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ That's it!
 
 See also [CONTRIBUTING.md](./CONTRIBUTING.md), especially [#known-issues](./CONTRIBUTING.md#known-issues)!
 
+## Deploying to Production
+
+See [./DEPLOYING.md](./DEPLOYING.md)
+
 ## Other accomplishments alongside this project
 
 > Some interesting stuff I've gone through thanks to this project
@@ -103,10 +107,6 @@ I found a tool that could generate API documentation automatically for my `expre
 ### Using github actions (CI) with `semantic-release` & `lerna` and finding the deeply hidden bug
 
 This one's worth a read:D https://github.com/actions/checkout/issues/217
-
-### & other goodies
-
-the list is not exhaustive. I appreciate open source & try to contribute if possible - I encourage you too!
 
 ## License
 

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
-	"short_name": "Turbo Schedule",
-	"name": "TT — Turbo Schedule",
+	"short_name": "TT",
+	"name": "Turbo Schedule",
 	"icons": [
 		{
 			"src": "favicon.ico",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,60 @@
+import React, { FC } from "react";
+import { Router, Switch, Route } from "react-router-dom";
+
+import "./App.scss";
+
+import { SchedulePageDesktop } from "./components/studentSchedule/SchedulePageDesktop";
+import CurrentLangContextProvider from "./components/currentLangContext/CurrentLangContextProvider";
+
+/** pages */
+import Landing from "./components/landing/Landing";
+import StudentSchedule from "./components/studentSchedule/StudentSchedule";
+
+/** misc */
+import { history } from "./utils/history";
+
+import { logCoolStuff } from "./utils/logCoolStuff";
+
+logCoolStuff();
+
+const App: FC = () => (
+	<>
+		<CurrentLangContextProvider>
+			<div className="App">
+				<div>
+					<Router history={history}>
+						<Switch>
+							<Route exact path="/" component={Landing} />
+							<Route exact path="/:studentName" component={StudentSchedule} />
+							<Route exact path="/:studentName/:dayIndex" component={StudentSchedule} />
+							<Route exact path="/:studentName/:dayIndex/:timeIndex" component={StudentSchedule} />
+							<Route exact path="/:studentName/:dayIndex/\*" component={StudentSchedule} />
+							<Route exact path="/:studentName/:dayIndex/:timeIndex/\*" component={StudentSchedule} />
+
+							{/* BACKWARDS-COMPATIBILITY -- REMOVE LATER */}
+							<Route exact path="/student/:studentName" component={StudentSchedule} />
+
+							<Route exact path="/new/:participantHandle" component={SchedulePageDesktop} />
+						</Switch>
+					</Router>
+				</div>
+			</div>
+		</CurrentLangContextProvider>
+	</>
+
+	// <div className="App">
+	// 	<Landing />
+
+	// 	{/* <header className="App-header">
+	// 		<img src={logo} className="App-logo" alt="logo" />
+	// 		<p>
+	// 			Edit <code>src/App.tsx</code> and save to reload.
+	// 		</p>
+	// 		<a className="App-link" href="https://reactjs.org" target="_blank" rel="noopener noreferrer">
+	// 			Learn React
+	// 		</a>
+	// 	</header> */}
+	// </div>
+);
+
+export default App;

--- a/common/src/util/delay.ts
+++ b/common/src/util/delay.ts
@@ -3,3 +3,20 @@
 export const delay = async (ms: number): Promise<void> => {
 	await new Promise((resolve) => setTimeout(resolve, ms));
 };
+
+/**
+ * in situations where promises are mapped over
+ * and then called all together with `Promise.all`,
+ * the async `delay` will have no effect.
+ *
+ * To have actual delay, you'll need the synchronous one:
+ */
+export const delaySync = (ms: number): void => {
+	const start = Date.now();
+	let now = start;
+
+	// while (now - start < ms) {
+	while (start + ms > now) {
+		now = Date.now();
+	}
+};

--- a/scraper/src/index.ts
+++ b/scraper/src/index.ts
@@ -4,10 +4,25 @@ import { IScraperConfig, createScraperConfig } from "./config";
 export * from "./config";
 export * from "./wasScheduleUpdated";
 
-const scraper = async (outDir: string): Promise<void> => {
-	const config: IScraperConfig = createScraperConfig(outDir);
+const isCurrentlyScraping = (): boolean => false;
+const createLockfile = (): void => {};
+const removeLockfile = (): void => {};
 
-	await scrape(config);
+const scraper = async (outDir: string): Promise<void> => {
+	if (isCurrentlyScraping()) {
+		const path: string = "?";
+		throw new Error(`refusing to scrape - lockfile present at ${path}`);
+	}
+
+	try {
+		createLockfile();
+
+		const config: IScraperConfig = createScraperConfig(outDir);
+
+		await scrape(config);
+	} finally {
+		removeLockfile();
+	}
 };
 
 export default scraper;

--- a/scraper/src/scraper.ts
+++ b/scraper/src/scraper.ts
@@ -85,7 +85,9 @@ export const scrape = async (config: IScraperConfig): Promise<void> => {
 			participants = participants.slice(0, 10);
 		}
 
+		console.log("begin lesson collection");
 		const lessons: Lesson[] = await scrapeAndDoMagicWithLessonsFromParticipants(participants);
+		console.log("end lesson collection");
 
 		/**
 		 * done! Now just save to the database, log info etc.

--- a/scraper/src/util/prepareScheduleItems.ts
+++ b/scraper/src/util/prepareScheduleItems.ts
@@ -4,6 +4,8 @@ import { handleScheduleRowspans } from "./handleScheduleRowspans";
 import { removeUselessTdsFromSchedule } from "./removeUselessTdsFromSchedule";
 import { removeCheerioesCirculars } from "./removeCheerioesCirculars";
 
+let prevTime = new Date().getTime();
+
 const extractStudentName = (scheduleItems: Array<CheerioElement>): string | undefined => {
 	try {
 		/**
@@ -12,7 +14,12 @@ const extractStudentName = (scheduleItems: Array<CheerioElement>): string | unde
 		const studentNameAndClass: string | undefined =
 			scheduleItems[0].children[0].children[0].children[0].children[0].data;
 
-		console.log("studentNameAndClass", studentNameAndClass);
+		const time = new Date().getTime();
+		const diff = time - prevTime;
+
+		console.log("studentNameAndClass", diff, studentNameAndClass);
+
+		prevTime = time;
 
 		return studentNameAndClass;
 	} catch (err) {

--- a/scraper/src/util/scrapeAndDoMagicWithLessonsFromParticipants.ts
+++ b/scraper/src/util/scrapeAndDoMagicWithLessonsFromParticipants.ts
@@ -4,7 +4,7 @@ import {
 	NonUniqueLesson,
 	mergeDuplicateLessons,
 	sortLessons,
-	// delaySync,
+	delaySync,
 } from "@turbo-schedule/common";
 
 import { extractLessonFromTeacher } from "./extractLessons";
@@ -33,7 +33,7 @@ export const scrapeAndDoMagicWithLessonsFromParticipants = async (
 		lessonPromises.map(async (promise) => {
 			const result = await promise;
 
-			// delaySync(200);
+			delaySync(200);
 
 			return result;
 		})

--- a/scraper/src/wasScheduleUpdated.ts
+++ b/scraper/src/wasScheduleUpdated.ts
@@ -4,8 +4,16 @@ import { getFrontPageHtml } from "./util/getFrontPageHtml";
 import { createPageVersionIdentifier } from "./util/createPageVersionIdentifier";
 
 export const wasScheduleUpdated = async (): Promise<boolean> => {
-	const db: Db = await initDb();
-	const { pageVersionIdentifier } = await db.get("scrapeInfo").value();
+	let db: Db;
+	let pageVersionIdentifier: string;
+
+	try {
+		db = await initDb();
+		pageVersionIdentifier = await db.get("scrapeInfo").value().pageVersionIdentifier;
+	} catch (e) {
+		console.error("db file not initialized or corrupt -- returning `true` to force update. error:", e);
+		return true;
+	}
 
 	const frontPageHtml: string = await getFrontPageHtml();
 	const potentiallyUpdatedPageVersionIdentifier: string = createPageVersionIdentifier(frontPageHtml);

--- a/server/add.js
+++ b/server/add.js
@@ -1,0 +1,3 @@
+module.exports.add = function add(a, b) {
+	return a + b;
+}

--- a/server/preload.js
+++ b/server/preload.js
@@ -1,0 +1,78 @@
+/**
+ * usage:
+ *
+ * ```sh
+ * cat load.js - | node -i
+ * ```
+ *
+ * and then
+ *
+ * ```sh
+ * load()
+ * ```
+ */
+
+console.log("module", module);
+
+const info = `
+${new Array(20).fill("\n").join("")}
+----------
+preload.js
+----------
+
+usage:
+
+\`\`\`
+load("./path/to/js/file", "x")
+x
+\`\`\`
+`;
+
+// load("../client/build/static/js/runtime-main.11652960.js")
+// global['webpackJsonp@turbo-schedule/client'].push()
+
+let loadedModuleCount = 0;
+
+// const load = ({ entrypoint = "./dist/server", globalVarHolderName = "x" }) => {
+// const load = ({ entrypoint, globalVarHolderName } = { entrypoint: "./dist/server", globalVarHolderName: "x" }) => {
+const load = (entrypoint = "./dist/server", globalVarHolderName = "x") => {
+	console.log("entrypoint", entrypoint, "globalVarHolderName", globalVarHolderName);
+	require(entrypoint);
+
+	// global[globalVarHolderName] = { ...global.exports }; /** probably just {} */
+
+	loadDFS(global.module, globalVarHolderName);
+
+	console.log(
+		[
+			`loaded \`${loadedModuleCount}\` modules`,
+			// `created \`${Object.keys(global[globalVarHolderName]).length}\` exports`,
+			// `stored in \`${globalVarHolderName}\``,
+		].join("\n")
+	);
+};
+
+const loadDFS = (module, globalVarHolderName) => {
+	if (!module || module.path.includes("node_modules")) {
+		return;
+	}
+
+	if (!globalVarHolderName) {
+		throw new Error(`[load] [error] globalVarHolderName not provided (was \`${globalVarHolderName}\`)`);
+	}
+
+	loadedModuleCount++;
+
+	console.log("module", loadedModuleCount, module.path);
+
+	// global[globalVarHolderName] = { ...global[globalVarHolderName], ...module.exports }; /** probably just {} */
+	// // global = { ...global, ...module.exports };
+	Object.assign(global, module.exports);
+
+	module.children.forEach((childModule) => {
+		loadDFS(childModule, globalVarHolderName);
+	});
+};
+
+console.log(info);
+

--- a/server/src/script/start-server.ts
+++ b/server/src/script/start-server.ts
@@ -14,4 +14,5 @@ process.on("SIGINT", () => {
 	process.exit();
 });
 
-startServer();
+	startServer();
+

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -123,3 +123,6 @@ export function startServer({
 
 	return server;
 }
+
+(global as any).app = app;
+(global as any).srv = startServer;


### PR DESCRIPTION
draft, saved for later; might include unrelated changes

the problem does not exist in the production environment
(I suppose that perhaps docker on the underlying VPS is somehow
cleverly limiting traffic so that it does not overload the upstream,
but it's unclear if it's true and how one could replicate it.)

note that the previous scraper, somewhere in `v1.x`,
worked fine and didn't overload the upstream.
It might be that upstream changed their load capacity,
and thus it's a coincidence, but we should explore
the previous version and see how/why it might've worked
and try to replicate it.

And that's pretty much exactly what I've tried to achieve here.