### PR TITLE
feat: type-safe express router

### DIFF
--- a/patches/@types+express+4.17.2.patch
+++ b/patches/@types+express+4.17.2.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@types/express/index.d.ts b/node_modules/@types/express/index.d.ts
+index e60c0dc..b97ac1a 100644
+--- a/node_modules/@types/express/index.d.ts
++++ b/node_modules/@types/express/index.d.ts
+@@ -99,7 +99,7 @@ declare namespace e {
+     interface Request<P extends core.Params = core.ParamsDictionary> extends core.Request<P> { }
+     interface RequestHandler<P extends core.Params = core.ParamsDictionary> extends core.RequestHandler<P> { }
+     interface RequestParamHandler extends core.RequestParamHandler { }
+-    export interface Response extends core.Response { }
++    export interface Response<T = any> extends core.Response<T> { }
+     interface Router extends core.Router { }
+     interface Send extends core.Send { }
+ }

--- a/patches/@types+express-serve-static-core+4.17.0.patch
+++ b/patches/@types+express-serve-static-core+4.17.0.patch
@@ -1,17 +1,21 @@
 diff --git a/node_modules/@types/express-serve-static-core/index.d.ts b/node_modules/@types/express-serve-static-core/index.d.ts
-index dc77fbc..70ab7a4 100644
+index dc77fbc..2b85d6c 100644
 --- a/node_modules/@types/express-serve-static-core/index.d.ts
 +++ b/node_modules/@types/express-serve-static-core/index.d.ts
-@@ -492,6 +492,8 @@ export interface MediaType {
+@@ -492,6 +492,12 @@ export interface MediaType {
  
  export type Send<ResBody = any, T = Response<ResBody>> = (body?: ResBody) => T;
  
-+export type Sender<ResBody = any> = (code: number, body?: ResBody) => void;
++// export type Sender<ResBody = any> = (code: number, body?: ResBody) => void;
++export interface Sender<ResBody = any> {
++	(code: number, data: ResBody, shouldMergeDefaultData: false): void;
++	(code: number, data: Partial<ResBody>, shouldMergeDefaultData?: true | undefined): void;
++}
 +
  export interface Response<ResBody = any> extends http.ServerResponse, Express.Response {
      /**
       * Set status `code`.
-@@ -535,6 +537,11 @@ export interface Response<ResBody = any> extends http.ServerResponse, Express.Re
+@@ -535,6 +541,11 @@ export interface Response<ResBody = any> extends http.ServerResponse, Express.Re
       */
      send: Send<ResBody, this>;
  

--- a/patches/@types+express-serve-static-core+4.17.0.patch
+++ b/patches/@types+express-serve-static-core+4.17.0.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@types/express-serve-static-core/index.d.ts b/node_modules/@types/express-serve-static-core/index.d.ts
+index dc77fbc..70ab7a4 100644
+--- a/node_modules/@types/express-serve-static-core/index.d.ts
++++ b/node_modules/@types/express-serve-static-core/index.d.ts
+@@ -492,6 +492,8 @@ export interface MediaType {
+ 
+ export type Send<ResBody = any, T = Response<ResBody>> = (body?: ResBody) => T;
+ 
++export type Sender<ResBody = any> = (code: number, body?: ResBody) => void;
++
+ export interface Response<ResBody = any> extends http.ServerResponse, Express.Response {
+     /**
+      * Set status `code`.
+@@ -535,6 +537,11 @@ export interface Response<ResBody = any> extends http.ServerResponse, Express.Re
+      */
+     send: Send<ResBody, this>;
+ 
++	/**
++	 * custom. available when used together with the `withSender` middleware
++	 */
++	sender: Sender<ResBody>;
++
+     /**
+      * Send JSON response.
+      *

--- a/patches/README.md
+++ b/patches/README.md
@@ -2,3 +2,4 @@
 
 * `express-oas-generator` - https://github.com/mpashkovskiy/express-oas-generator/issues/37#issuecomment-582141420
 * `lowdb` and `@types/lowdb` - https://github.com/typicode/lowdb/issues/385
+* `@types/express`  - [already fixed](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/03fa4ecc7ecbe94e50b5e5fe03d7add64a198198), but the fixes (also previous ones back to the version we are using) break other behavior, so we're staying with a patch for now.

--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
 	"version": "2.23.1",
 	"description": "",
 	"main": "dist/src/server.js",
-	"typings": "dist/src/server.d.ts",
+	"typings": "dist/src/index.d.ts",
 	"author": "Kipras Melnikovas <dev@kipras.org> (https://kipras.org)",
 	"license": "",
 	"scripts": {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * type definitions et al
+ */
+
+export * from "./server";
+export * from "./route/apiRouter";

--- a/server/src/middleware/withSender.ts
+++ b/server/src/middleware/withSender.ts
@@ -1,0 +1,25 @@
+/* eslint-disable indent */
+
+import { Request, Response, NextFunction } from "express";
+
+import { isProd } from "../util/isProd";
+
+export interface WithErr<E = unknown> {
+	err?: E;
+}
+
+export const createSender = <_T, E = unknown, T extends _T & WithErr<E> = _T & WithErr<E>>(
+	res: Response<T>, //
+	next: NextFunction,
+	defaultData: T
+) => (code: number, data: T = defaultData): void => {
+	res.status(code).json(data);
+	if (data.err) console.error(data.err);
+	return !isProd() ? (data.err ? next(data.err) : next()) : res.end();
+};
+
+export const withSender = <T>(defaultData: T) => (_req: Request, res: Response<T>, next: NextFunction): void => {
+	const send = createSender(res, next, defaultData);
+	res.sender = send;
+	next();
+};

--- a/server/src/middleware/withSender.ts
+++ b/server/src/middleware/withSender.ts
@@ -1,6 +1,7 @@
 /* eslint-disable indent */
 
 import { Request, Response, NextFunction } from "express";
+import { Sender } from "express-serve-static-core";
 
 import { isProd } from "../util/isProd";
 
@@ -8,15 +9,47 @@ export interface WithErr<E = unknown> {
 	err?: E;
 }
 
-export const createSender = <_T, E = unknown, T extends _T & WithErr<E> = _T & WithErr<E>>(
+export function createSender<_T, E = unknown, T extends _T & WithErr<E> = _T & WithErr<E>>(
 	res: Response<T>, //
 	next: NextFunction,
 	defaultData: T
-) => (code: number, data: T = defaultData): void => {
-	res.status(code).json(data);
-	if (data.err) console.error(data.err);
-	return !isProd() ? (data.err ? next(data.err) : next()) : res.end();
-};
+): Sender<T> {
+	function sender(
+		code: number,
+		_data: typeof shouldMergeDefaultData extends true | undefined ? Partial<T> : T,
+		shouldMergeDefaultData: false
+	): void;
+
+	function sender(
+		code: number,
+		_data: typeof shouldMergeDefaultData extends true | undefined ? Partial<T> : T,
+		shouldMergeDefaultData?: true
+	): void;
+
+	function sender(
+		code: number, //
+		_data: T | Partial<T>,
+		shouldMergeDefaultData: false | true = true
+	): void {
+		/**
+		 * `as T` is still sound here,
+		 * because either the data is already T,
+		 * or it is Partial<T> and then we merge the default data,
+		 * making it T too.
+		 */
+		let data: T = _data as T;
+
+		if (shouldMergeDefaultData) {
+			data = { ...defaultData, ...data };
+		}
+
+		res.status(code).json(data);
+		if (data.err) console.error(data.err);
+		return !isProd() ? (data.err ? next(data.err) : next()) : res.end();
+	}
+
+	return sender;
+}
 
 export const withSender = <T>(defaultData: T) => (_req: Request, res: Response<T>, next: NextFunction): void => {
 	const send = createSender(res, next, defaultData);

--- a/server/src/route/apiRouter.ts
+++ b/server/src/route/apiRouter.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+
 import { apiRouterV1 } from "./v1/apiV1";
 import { redirectToApiDocs } from "../util/redirectToApiDocs";
 
@@ -9,3 +10,5 @@ router.use("/v1", apiRouterV1);
 router.use("/", redirectToApiDocs);
 
 export { router as apiRouter };
+
+export * from "./v1/apiV1";

--- a/server/src/route/v1/apiV1.ts
+++ b/server/src/route/v1/apiV1.ts
@@ -25,3 +25,12 @@ router.use("/docs.json", openAPIDocsJSONHandler);
 router.use("/", redirectToApiDocs);
 
 export { router as apiRouterV1 };
+
+export * from "./participant";
+/**
+ * TODO: type-safe routes with exported response types:
+ */
+// export * from "./class";
+// export * from "./student";
+// export * from "./teacher";
+// export * from "./room";

--- a/server/src/route/v1/participant.ts
+++ b/server/src/route/v1/participant.ts
@@ -38,12 +38,12 @@ router.get<any, ParticipantsRes>("/", withSender({ participants: [] }), async (_
 		const participants: Participant[] = await db.get("participants").value();
 
 		if (!participants?.length) {
-			return send(404, { participants: [], err: `Schedule items not found (were \`${participants}\`)` });
+			return send(404, { err: `Schedule items not found (were \`${participants}\`)` });
 		}
 
 		return send(200, { participants });
 	} catch (err) {
-		return send(500, { participants: [], err });
+		return send(500, { err });
 	}
 });
 
@@ -79,7 +79,7 @@ router.get<any, ParticipantRandomRes>("/random", withSender({ participants: [] }
 			}
 		}
 	} catch (err) {
-		return send(500, { participants: [], err });
+		return send(500, { err });
 	}
 });
 
@@ -120,7 +120,6 @@ router.get<any, ParticipantCommonAvailabilityRes>(
 
 			if (!wantedParticipants.length) {
 				return send(400, {
-					...getDefaultParticipantCommonAvailRes(),
 					err: `Request query \`wanted-participants\` was empty (${wantedParticipants})`,
 				});
 			}
@@ -216,10 +215,7 @@ router.get<any, ParticipantCommonAvailabilityRes>(
 				availability,
 			});
 		} catch (err) {
-			return send(500, {
-				...getDefaultParticipantCommonAvailRes(),
-				err,
-			});
+			return send(500, { err });
 		}
 	}
 );
@@ -239,10 +235,7 @@ router.get<any, ParticipantClassifyRes>("/classify", withSender({ participants: 
 				.filter((p: string) => !!p) ?? [];
 
 		if (!participants.length) {
-			return send(400, {
-				participants: [],
-				err: `No participants included in request.query (${participants})`,
-			});
+			return send(400, { err: `No participants included in request.query (${participants})` });
 		}
 
 		const db: Db = await initDb();
@@ -255,7 +248,7 @@ router.get<any, ParticipantClassifyRes>("/classify", withSender({ participants: 
 
 		return send(200, { participants: classifiedParticipants });
 	} catch (err) {
-		return send(500, { participants: [], err });
+		return send(500, { err });
 	}
 });
 
@@ -273,8 +266,8 @@ router.get<any, ParticipantDuplicatesRes>("/debug/duplicates", withSender({ dupl
 		const duplicates = findParticipantsWithMultipleLessonsInSameTime(participants, lessons);
 
 		return res.sender(200, { duplicates });
-	} catch (e) {
-		return res.sender(500, { duplicates: {}, err: e });
+	} catch (err) {
+		return res.sender(500, { err });
 	}
 });
 
@@ -304,10 +297,7 @@ router.get<any, ParticipantScheduleByNameRes>(
 				.value();
 
 			if (!participant) {
-				return send(404, {
-					participant: getDefaultParticipant(),
-					err: `Participant not found (was \`${participant}\`)`,
-				});
+				return send(404, { err: `Participant not found (was \`${participant}\`)` });
 			}
 
 			const lessons: Lesson[] = await db
@@ -323,7 +313,7 @@ router.get<any, ParticipantScheduleByNameRes>(
 
 			return send(200, { participant: participantWithLessons });
 		} catch (err) {
-			return send(500, { participant: getDefaultParticipant(), err });
+			return send(500, { err });
 		}
 	}
 );


### PR DESCRIPTION
currently implemented for `/participant/*`, other resources will not even need this since we'll re-route everything to `/participant/*` anyway