### PR TITLE
fix: pool promises (lazily) @ scraper to avoid overloading upstream & succeed at scraping, even if takes longer

### DIFF
--- a/client/src/components/navbar/StickyWarningAboutOutdatedData.tsx
+++ b/client/src/components/navbar/StickyWarningAboutOutdatedData.tsx
@@ -56,7 +56,8 @@ export function StickyWarningAboutOutdatedData(): ReturnType<React.FC> {
 	/**
 	 * actually does "floor" since the comparison is reversed.
 	 */
-	let ago = date.getTime() - new Date().getTime();
+	const agoMs = new Date().getTime() - date.getTime();
+	let ago: number = -agoMs;
 
 	ago =
 		intervalOfTimeAgo === "minute"
@@ -87,7 +88,21 @@ export function StickyWarningAboutOutdatedData(): ReturnType<React.FC> {
 				css`
 					position: sticky;
 					width: 100%;
-					background-color: hsl(45, 100%, 50%);
+					background-color: ${!agoMs
+						? "hsl(0, 10%, 90%)"
+						: /**
+						 *
+						 * if > 1 day passed,
+						 * +1h for buffer for confirming
+						 * since we collect every 24h,
+						 *
+						 * show orange (warning);
+						 * otherwise, show light blue (info).
+						 *
+						 */
+						agoMs >= 1000 * 60 * 60 * (24 + 1)
+						? "hsl(45, 100%, 50%)"
+						: "hsl(210, 100%, 90%)"};
 				`,
 				{
 					[css`

--- a/common/src/index.ts
+++ b/common/src/index.ts
@@ -11,6 +11,7 @@ export * from "./util/LRUCache";
 export * from "./util/scraperSpecificParticipantClassifier"; /** TODO FIXME */
 export * from "./util/hierarchy"; /** TODO FIXME */
 export * from "./util/noop";
+export * from "./util/poolPromises";
 
 export * from "./model/Participant";
 export * from "./model/Schedule";

--- a/common/src/model/Schedule.ts
+++ b/common/src/model/Schedule.ts
@@ -1,7 +1,7 @@
 /**
  * same for everyone - students, classes, teachers etc.
  */
-export const frontPageScheduleURI: string = `https://pranciskonugimnazija.lt/tvarkarastis/`;
+export const frontPageScheduleURI: string = `https://pranciskonugimnazija.lt/tvarkarastis/index.htm`;
 
 /** TODO RENAME to `getOriginalScheduleURI` */
 export const getSpecificScheduleURI = (href: string): string =>

--- a/common/src/util/getHtml.ts
+++ b/common/src/util/getHtml.ts
@@ -4,14 +4,19 @@ import iconv from "iconv-lite";
 /** https://stackoverflow.com/a/9049823 */
 export const getHtml = async (url: string, encoding: string = "utf-8"): Promise<string> => {
 	try {
-		const response = await fetch(url);
+		const response = await fetch(url, {
+			headers: {
+				"User-Agent":
+					"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 Safari/537.36 OPR/38.0.2220.41",
+			},
+		});
 
 		/** See https://github.github.io/fetch#Error */
 		if (!response.ok) {
 			const err: Error = new Error(response.statusText);
 
 			console.error("Failed @ `getHtml`:", err);
-			return Promise.reject(err);
+			throw err;
 		}
 
 		const dataBuffer: Buffer = await response.buffer();
@@ -22,6 +27,6 @@ export const getHtml = async (url: string, encoding: string = "utf-8"): Promise<
 	} catch (err) {
 		/** this probably will never be reached */
 		console.error("Error! Failed to `getHtml`: ", err);
-		return Promise.reject(new Error(err as any));
+		throw err;
 	}
 };

--- a/common/src/util/poolPromises.ts
+++ b/common/src/util/poolPromises.ts
@@ -1,0 +1,57 @@
+import { delay } from "./delay";
+
+/**
+ * returns a `getTimeDeltaMs` function
+ */
+export const startTimerMs: (opts?: { startTime?: number; divider?: number }) => (endTime?: number) => number = (
+	{
+		startTime = new Date().getTime(), //
+		divider = 1,
+	} = {} //
+) => (
+	endTime = new Date().getTime() //
+) => (endTime - startTime) / divider;
+
+export type PromiseCreator<T> = () => Promise<T>;
+
+/**
+ * the whole purpose is that a promise is not yet initiated,
+ * i.e. its "lazy",
+ * i.e. it's not yet called, and instead it's made lazy
+ * by initially wrapping it inside another function
+ * (thus becoming "PromiseCreator").
+ *
+ */
+export const poolPromises = async <T>(
+	intervalMs: number, //
+	maxRequestsPerIntervalIncl: number,
+	arrayOfPromiseCreators: PromiseCreator<T>[] = []
+): Promise<T[]> => {
+	const results: T[][] = [];
+
+	while (arrayOfPromiseCreators.length > 0) {
+		const current: PromiseCreator<T>[] = arrayOfPromiseCreators.splice(0, maxRequestsPerIntervalIncl);
+
+		console.log(
+			"pool", //
+			results.length,
+			"current",
+			current.length,
+			"remaining",
+			arrayOfPromiseCreators.length, // - results.length
+			"results",
+			results.length * (results[results.length - 1]?.length || 1)
+		);
+
+		const getDeltaMs = startTimerMs();
+
+		const tmpResults: T[] = await Promise.all(current.map((promiseCreator) => promiseCreator()));
+
+		results.push(tmpResults);
+
+		console.log("delta", getDeltaMs() / 1000);
+		await delay(intervalMs - getDeltaMs());
+	}
+
+	return results.flat();
+};


### PR DESCRIPTION
the `maxRequestsPerIntervalIncl` default of `5` is quite arbitrary,
just like you'd expect.

seems to work just fine ofc.

Signed-off-by: Kipras Melnikovas <kipras@kipras.org>